### PR TITLE
FR-236 - Merge Safari Pysolr with upstream 3.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,30 @@
+sudo: false
 language: python
 python:
-  - "2.7"
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "pypy"
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install default-jdk
-  - pip install requests
+cache:
+  apt: true
+  pip: true
+  directories:
+      - $HOME/download-cache
 
-before_script:
-  - python get-solr-download-url.py 4.7.2 | xargs curl -sSO
+addons:
+  apt_packages:
+    - default-jdk
 
 install:
-  - pip install tox
+    - "pip install 'requests>2'"
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
+    - "pip install ."
 
 script:
-  - tox -e $TOX_ENV
-
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py26-tomcat
-  - TOX_ENV=py27-tomcat
-  - TOX_ENV=py33-tomcat
-  - TOX_ENV=py34-tomcat
+    - python run-tests.py
 
 notifications:
-  #irc: "irc.freenode.org#pysolr"
-  email: false
+    # irc: "irc.freenode.org#pysolr"
+    email: false

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Primaries:
 * Joseph Kocherhans
 * Daniel Lindsley
 * Jacob Kaplan-Moss
+* Chris Adams
 
 
 Contributors:

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,7 @@ Requirements
 
 * Python 2.6 - 3.3
 * Requests 2.0+
-* **Optional** - ``lxml``
 * **Optional** - ``simplejson``
-* **Optional** - ``cssselect`` for Tomcat error support
 
 
 Installation
@@ -64,22 +62,17 @@ Basic usage looks like:
         {
             "id": "doc_2",
             "title": "The Banana: Tasty or Dangerous?",
-            "_doc": [ 
+            "_doc": [
                 { "id": "child_doc_1", "title": "peel" },
                 { "id": "child_doc_2", "title": "seed" },
             ]
         },
     ])
 
-    # You can index a parent/child document relationship by 
+    # You can index a parent/child document relationship by
     # associating a list of child documents with the special key '_doc'. This
     # is helpful for queries that join together conditions on children and parent
     # documents.
-
-    # You can optimize the index when it gets fragmented, for better speed,
-    # although it's generally better for performance overall to let Lucene
-    # decide when to do this automatically.
-    solr.optimize()
 
     # Later, searching is easy. In the simple case, just a plain Lucene-style
     # query is fine.

--- a/get-solr-download-url.py
+++ b/get-solr-download-url.py
@@ -9,7 +9,7 @@ import requests
 
 # Try to import urljoin from the Python 3 reorganized stdlib first:
 try:
-    from urlparse.parse import urljoin
+    from urllib.parse import urljoin
 except ImportError:
     from urlparse import urljoin
 

--- a/run-tests.py
+++ b/run-tests.py
@@ -39,10 +39,8 @@ def start_solr():
 def main():
     solr_proc = start_solr()
 
-    if sys.version_info >= (3, 3):
+    if sys.version_info >= (3, 3) or sys.version_info >= (2, 7):
         cmd = ['python', '-m', 'unittest', 'tests']
-    elif sys.version_info >= (2, 7):
-        cmd = ['python', '-m', 'unittest2', 'tests']
     else:
         cmd = ['unit2', 'discover', '-s', 'tests', '-p', '[a-z]*.py']
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name="pysolr",
-    version="3.2.0-safari1",
+    version="3.3.2-safari1",
     description="Lightweight python wrapper for Apache Solr.",
     author='Daniel Lindsley',
     author_email='daniel@toastdriven.com',
@@ -28,11 +28,5 @@ setup(
     license='BSD',
     install_requires=[
         'requests>=2.0'
-    ],
-    extras_require={
-        'tomcat': [
-            'lxml>=3.0',
-            'cssselect',
-        ],
-    }
+    ]
 )

--- a/start-test-solr.sh
+++ b/start-test-solr.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-SOLR_VERSION=4.7.2
+SOLR_VERSION=4.10.4
 
 export SOLR_ARCHIVE="${SOLR_VERSION}.tgz"
 

--- a/start-test-solr.sh
+++ b/start-test-solr.sh
@@ -4,15 +4,26 @@ set -e
 
 SOLR_VERSION=4.7.2
 
-if [ ! -f solr-${SOLR_VERSION}.tgz ]; then
-    python get-solr-download-url.py $SOLR_VERSION | xargs curl -O
+export SOLR_ARCHIVE="${SOLR_VERSION}.tgz"
+
+if [ -d "${HOME}/download-cache/" ]; then
+    export SOLR_ARCHIVE="${HOME}/download-cache/${SOLR_ARCHIVE}"
+fi
+
+if [ -f ${SOLR_ARCHIVE} ]; then
+    # If the tarball doesn't extract cleanly, remove it so it'll download again:
+    tar -tf ${SOLR_ARCHIVE} > /dev/null || rm ${SOLR_ARCHIVE}
+fi
+
+if [ ! -f ${SOLR_ARCHIVE} ]; then
+    python get-solr-download-url.py $SOLR_VERSION | xargs curl -Lo $SOLR_ARCHIVE
 fi
 
 echo "Extracting Solr ${SOLR_VERSION} to solr4/"
 rm -rf solr4
 mkdir solr4
-tar -C solr4 -xf solr-${SOLR_VERSION}.tgz --strip-components 2 solr-${SOLR_VERSION}/example
-tar -C solr4 -xf solr-${SOLR_VERSION}.tgz --strip-components 1 solr-${SOLR_VERSION}/dist solr-${SOLR_VERSION}/contrib
+tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 2 solr-${SOLR_VERSION}/example
+tar -C solr4 -xf ${SOLR_ARCHIVE} --strip-components 1 solr-${SOLR_VERSION}/dist solr-${SOLR_VERSION}/contrib
 
 echo "Configuring Solr"
 cd solr4

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,9 @@
 [tox]
-envlist = py26,py27,py33,py34,py26-tomcat,py27-tomcat,py33-tomcat,py34-tomcat
+envlist = py26,py27,py33,py34
 
 [base]
 deps =
     requests>=2.0
-
-[tomcat]
-deps =
-    lxml>=3
-    cssselect
 
 [testenv]
 commands = {toxinidir}/run-tests.py
@@ -17,32 +12,3 @@ commands = {toxinidir}/run-tests.py
 deps =
     unittest2
     {[base]deps}
-
-[testenv:py27]
-deps =
-    unittest2
-    {[base]deps}
-
-[testenv:py26-tomcat]
-basepython = python2.6
-deps =
-    {[testenv:py26]deps}
-    {[tomcat]deps}
-
-[testenv:py27-tomcat]
-basepython = python2.7
-deps =
-    {[testenv:py27]deps}
-    {[tomcat]deps}
-
-[testenv:py33-tomcat]
-basepython = python3.3
-deps =
-    {[base]deps}
-    {[tomcat]deps}
-
-[testenv:py34-tomcat]
-basepython = python3.4
-deps =
-    {[base]deps}
-    {[tomcat]deps}


### PR DESCRIPTION
We have forked Pysolr from https://github.com/toastdriven/pysolr, to add a couple of extra features.

I believe that these relatively small changes have been submitted as a PR to the main branch, but have not been accepted (it looks like this is not uncommon, from what I have gleaned, but don't take that for certain). I do intend to submit these changes again, but for the minute we should continue to use our fork.

This PR just pulls in the upstream changes from the 'toastdriven' branch. 

One test fails, but that test failed with our previous version on our fork (I actually haven't seen it pass at all, even on a clean branch, and it doesn't seem critical to understand exactly why). All other tests pass.

When I include this new version of Pysolr in Falcon, all Falcon tests pass (and I have tried deliberately breaking this Pysolr to be certain that it was picking up this version — it broke as expected).

Therefore, I think we should merge this into the master branch of our Pysolr branch. Then we should create a new egg, and update the version in Falcon.